### PR TITLE
Xnor/juce updates

### DIFF
--- a/App.cmake
+++ b/App.cmake
@@ -45,6 +45,10 @@ target_sources(RNBOApp
   ${RNBO_CPP_DIR}/adapters/juce/RNBO_JuceAudioProcessor.cpp
   )
 
+if (EXISTS ${RNBO_BINARY_DATA_FILE})
+  target_sources(RNBOApp PRIVATE ${RNBO_BINARY_DATA_FILE})
+endif()
+
 include_directories(
   "src"
   "${RNBO_CPP_DIR}/"
@@ -81,6 +85,3 @@ target_link_libraries(RNBOApp
   juce::juce_recommended_lto_flags
   juce::juce_recommended_warning_flags)
 
-if(HAS_BINARY_RESOURCES)
-  target_link_libraries(RNBOApp PRIVATE BinaryResources)
-endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,13 +15,12 @@ set(CMAKE_COLOR_DIAGNOSTICS ON)
 set(RNBO_CPP_DIR "${CMAKE_CURRENT_SOURCE_DIR}/export/rnbo/" CACHE FILEPATH "The path to the the RNBO c++ source directory")
 set(RNBO_EXPORT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/export/description.json" CACHE FILEPATH "path to description.json")
 
+set(RNBO_CLASS_NAME "rnbomatic")
 set(RNBO_CLASS_FILE "${RNBO_EXPORT_DIR}/rnbo_source.cpp")
 set(RNBO_DESCRIPTION_FILE "${RNBO_EXPORT_DIR}/description.json")
 set(RNBO_PRESETS_FILE "${RNBO_EXPORT_DIR}/presets.json")
-set(RNBO_BINARY_DATA_FILE "${RNBO_EXPORT_DIR}/rnbo_binary.cpp")
-
-set(RNBO_BINARY_DATA_STORAGE_NAME "RNBOPatcherBinaryData" CACHE STRING "name of the extern binary data")
-mark_as_advanced(RNBO_BINARY_DATA_STORAGE_NAME)
+set(RNBO_BINARY_DATA_FILE "${RNBO_EXPORT_DIR}/${RNBO_CLASS_NAME}_binary.cpp")
+set(RNBO_BINARY_DATA_STORAGE_NAME "${RNBO_CLASS_NAME}_binary")
 
 #write description header file if description.json exists, sets RNBO_INCLUDE_DESCRIPTION_FILE if the file exists
 include(${RNBO_CPP_DIR}/cmake/RNBODescriptionHeader.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,8 @@ cmake_minimum_required(VERSION 3.15)
 # On M1 Macs, uncomment to enable universal binaries
 # set(CMAKE_OSX_ARCHITECTURES "x86_64;arm64" CACHE STRING "")
 
+set(CMAKE_BUILD_TYPE Debug CACHE STRING "Choose the type of build, options are: Debug Release")
+
 project(RNBO_JUCE_EXAMPLE VERSION 2.0.0)
 
 set(CMAKE_CXX_STANDARD 14) #JUCE requires 14
@@ -10,23 +12,26 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_COLOR_MAKEFILE ON)
 set(CMAKE_COLOR_DIAGNOSTICS ON)
 
-if(NOT CMAKE_BUILD_TYPE)
-  set(CMAKE_BUILD_TYPE Debug CACHE STRING "Choose the type of build, options are: Debug Release" FORCE)
-endif()
-
-set(RNBO_EXPORT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/export" CACHE FILEPATH "The path to all exported resources")
 set(RNBO_CPP_DIR "${CMAKE_CURRENT_SOURCE_DIR}/export/rnbo/" CACHE FILEPATH "The path to the the RNBO c++ source directory")
-set(RNBO_CLASS_FILE "${CMAKE_CURRENT_SOURCE_DIR}/export/rnbo_source.cpp" CACHE FILEPATH "The file that holds the generated RNBO class code")
-set(RNBO_PRESETS_FILE "${CMAKE_CURRENT_SOURCE_DIR}/export/presets.json" CACHE FILEPATH "path to presets.json, set invalid to not include any presets")
+set(RNBO_EXPORT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/export/description.json" CACHE FILEPATH "path to description.json")
 
-set(INCLUDE_SAMPLES ON CACHE BOOL "Should the project include samples if the dependencies.json file is found?")
+set(RNBO_CLASS_FILE "${RNBO_EXPORT_DIR}/rnbo_source.cpp")
+set(RNBO_DESCRIPTION_FILE "${RNBO_EXPORT_DIR}/description.json")
+set(RNBO_PRESETS_FILE "${RNBO_EXPORT_DIR}/presets.json")
+set(RNBO_BINARY_DATA_FILE "${RNBO_EXPORT_DIR}/rnbo_binary.cpp")
+
+set(RNBO_BINARY_DATA_STORAGE_NAME "RNBOPatcherBinaryData" CACHE STRING "name of the extern binary data")
+mark_as_advanced(RNBO_BINARY_DATA_STORAGE_NAME)
 
 #write description header file if description.json exists, sets RNBO_INCLUDE_DESCRIPTION_FILE if the file exists
 include(${RNBO_CPP_DIR}/cmake/RNBODescriptionHeader.cmake)
 set(DESCRIPTION_INCLUDE_DIR ${CMAKE_BINARY_DIR}/include)
-rnbo_write_description_header_if_exists(${RNBO_EXPORT_DIR}/description.json ${DESCRIPTION_INCLUDE_DIR} ${RNBO_PRESETS_FILE})
+rnbo_write_description_header_if_exists(${RNBO_DESCRIPTION_FILE} ${DESCRIPTION_INCLUDE_DIR} ${RNBO_PRESETS_FILE})
 include_directories(${DESCRIPTION_INCLUDE_DIR})
 
+if (EXISTS ${RNBO_BINARY_DATA_FILE})
+	add_definitions(-DRNBO_BINARY_DATA_STORAGE_NAME=${RNBO_BINARY_DATA_STORAGE_NAME})
+endif()
 
 # Include the JUCE submodule, needed for JUCE-based CMake definitions
 add_subdirectory(
@@ -46,23 +51,6 @@ add_subdirectory(
 # Comment out this line if you really want to emulate MIDI CC with Audio Parameters.
 # See the discussion here: https://forums.steinberg.net/t/vst3-and-midi-cc-pitfall/201879/11
 add_compile_definitions(JUCE_VST3_EMULATE_MIDI_CC_WITH_PARAMETERS=0)
-
-set(BINARY_RESOURCES "")
-set(HAS_BINARY_RESOURCES FALSE)
-
-if(INCLUDE_SAMPLES AND EXISTS "${RNBO_EXPORT_DIR}/dependencies.json")
-  set(HAS_BINARY_RESOURCES TRUE)
-  list(APPEND BINARY_RESOURCES "${RNBO_EXPORT_DIR}/dependencies.json")
-  if(EXISTS "${RNBO_EXPORT_DIR}/media")
-    file(GLOB dependency_sources "${RNBO_EXPORT_DIR}/media/*")
-    list(APPEND BINARY_RESOURCES ${dependency_sources})
-  endif()
-endif()
-
-# Add binary resources if they exist
-if(HAS_BINARY_RESOURCES)
-  juce_add_binary_data(BinaryResources SOURCES ${BINARY_RESOURCES})
-endif()
 
 # setup your application, you can remove this include if you don't want to build applications
 include(${CMAKE_CURRENT_LIST_DIR}/App.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ set(CMAKE_COLOR_MAKEFILE ON)
 set(CMAKE_COLOR_DIAGNOSTICS ON)
 
 set(RNBO_CPP_DIR "${CMAKE_CURRENT_SOURCE_DIR}/export/rnbo/" CACHE FILEPATH "The path to the the RNBO c++ source directory")
-set(RNBO_EXPORT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/export/description.json" CACHE FILEPATH "path to description.json")
+set(RNBO_EXPORT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/export/" CACHE FILEPATH "path to your epxort directory")
 
 set(RNBO_CLASS_NAME "rnbomatic")
 set(RNBO_CLASS_FILE "${RNBO_EXPORT_DIR}/rnbo_source.cpp")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,14 +17,14 @@ endif()
 set(RNBO_EXPORT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/export" CACHE FILEPATH "The path to all exported resources")
 set(RNBO_CPP_DIR "${CMAKE_CURRENT_SOURCE_DIR}/export/rnbo/" CACHE FILEPATH "The path to the the RNBO c++ source directory")
 set(RNBO_CLASS_FILE "${CMAKE_CURRENT_SOURCE_DIR}/export/rnbo_source.cpp" CACHE FILEPATH "The file that holds the generated RNBO class code")
-set(INCLUDE_PRESETS ON CACHE BOOL "Should the project include presets if the presets.json file is found?")
-set(INCLUDE_SAMPLES ON CACHE BOOL "Should the project include samples if the dependencies.json file is found?")
+set(RNBO_PRESETS_FILE "${CMAKE_CURRENT_SOURCE_DIR}/export/presets.json" CACHE FILEPATH "path to presets.json, set invalid to not include any presets")
 
+set(INCLUDE_SAMPLES ON CACHE BOOL "Should the project include samples if the dependencies.json file is found?")
 
 #write description header file if description.json exists, sets RNBO_INCLUDE_DESCRIPTION_FILE if the file exists
 include(${RNBO_CPP_DIR}/cmake/RNBODescriptionHeader.cmake)
 set(DESCRIPTION_INCLUDE_DIR ${CMAKE_BINARY_DIR}/include)
-rnbo_write_description_header_if_exists(${RNBO_EXPORT_DIR}/description.json ${DESCRIPTION_INCLUDE_DIR})
+rnbo_write_description_header_if_exists(${RNBO_EXPORT_DIR}/description.json ${DESCRIPTION_INCLUDE_DIR} ${RNBO_PRESETS_FILE})
 include_directories(${DESCRIPTION_INCLUDE_DIR})
 
 
@@ -49,11 +49,6 @@ add_compile_definitions(JUCE_VST3_EMULATE_MIDI_CC_WITH_PARAMETERS=0)
 
 set(BINARY_RESOURCES "")
 set(HAS_BINARY_RESOURCES FALSE)
-
-if(INCLUDE_PRESETS AND EXISTS "${RNBO_EXPORT_DIR}/presets.json")
-  set(HAS_BINARY_RESOURCES TRUE)
-  list(APPEND BINARY_RESOURCES "${RNBO_EXPORT_DIR}/presets.json")
-endif()
 
 if(INCLUDE_SAMPLES AND EXISTS "${RNBO_EXPORT_DIR}/dependencies.json")
   set(HAS_BINARY_RESOURCES TRUE)

--- a/CUSTOM_UI.md
+++ b/CUSTOM_UI.md
@@ -6,42 +6,8 @@ Please note, if you haven't yet followed the setup steps in `README.md`, you sho
 
 ## Switching to a Custom UI
 
-The files `src/CustomAudioProcessor` and `src/CustomAudioEditor` are starting points for a custom UI. `CustomAudioProcessor` returns `CustomAudioEditor` instead of the default `RNBO::JuceAudioProcessorEditor`, so the first step to making your own UI is to modify the code to use `CustomAudioProcessor` instead of the default `RNBO::JuceAudioProcessor`.
-
-### Standalone App Target
-To change the UI of the standalone app target, look in `src/MainComponent.cpp`. Find the declaration of the member variable `_audioProcessor` and switch it from `RNBO::JuceAudioProcessor` to `CustomAudioProcessor`.
-
-```cpp
-// std::unique_ptr<RNBO::JuceAudioProcessor>	_audioProcessor;
-std::unique_ptr<CustomAudioProcessor>		_audioProcessor;
-std::unique_ptr<AudioProcessorEditor>		_audioProcessorEditor;
-```
-
-In that same file, find the line in `loadRNBOAudioProcessor` where `_audioProcessor` is initialized, and change it to use the `CustomAudioProcessor`.
-
-```cpp
-// _audioProcessor = RNBO::make_unique<RNBO::JuceAudioProcessor>();
-_audioProcessor = RNBO::make_unique<CustomAudioProcessor>();
-```
-
-At the top of `MainComponent.cpp`, you'll also want to uncomment the line which will `#include` the header file we need
-
-```cpp
-#include "CustomAudioProcessor.h"
-```
-
-### Plugin Target
-To change the UI of the plugin target, look in `src/Plugin.cpp`. Change the `createPluginFilter` function to return the custom audio processor.
-
-```cpp
-AudioProcessor* JUCE_CALLTYPE createPluginFilter()
-{
-	// return new RNBO::JuceAudioProcessor();
-	return new CustomAudioProcessor();
-}
-```
-Just like we did for the Standalone App, at the top of `Plugin.cpp` you'll also want to uncomment the line that will include the `"CustomAudioProcessor.h"` header file.
-
+The files `src/CustomAudioProcessor` and `src/CustomAudioEditor` are starting points for a custom UI.
+`CustomAudioProcessor` returns `RNBO::JuceAudioProcessorEditor` by default, so the first step to making your own UI is to modify the code to return `CustomAudioProcessor` instead.
 
 ## Building a Custom UI with the Projucer
 

--- a/Plugin.cmake
+++ b/Plugin.cmake
@@ -56,6 +56,10 @@ target_sources(RNBOAudioPlugin PRIVATE
   src/CustomAudioProcessor.cpp
   )
 
+if (EXISTS ${RNBO_BINARY_DATA_FILE})
+  target_sources(RNBOAudioPlugin PRIVATE ${RNBO_BINARY_DATA_FILE})
+endif()
+
 include_directories(
   "${RNBO_CPP_DIR}/"
   "${RNBO_CPP_DIR}/common/"
@@ -94,11 +98,6 @@ target_link_libraries(RNBOAudioPlugin
   juce::juce_recommended_lto_flags
   juce::juce_recommended_warning_flags
   )
-
-#samples and/or presets
-if (HAS_BINARY_RESOURCES)
-  target_link_libraries(RNBOAudioPlugin PRIVATE BinaryResources)
-endif()
 
 #TODO windows and linux
 if(APPLE)

--- a/src/CustomAudioEditor.h
+++ b/src/CustomAudioEditor.h
@@ -6,7 +6,7 @@ class CustomAudioEditor : public AudioProcessorEditor, private AudioProcessorLis
 {
 public:
     CustomAudioEditor(RNBO::JuceAudioProcessor* const p, RNBO::CoreObject& rnboObject);
-    ~CustomAudioEditor();
+    ~CustomAudioEditor() override;
     void paint (Graphics& g) override;
 
 private:

--- a/src/CustomAudioProcessor.cpp
+++ b/src/CustomAudioProcessor.cpp
@@ -1,7 +1,7 @@
 #include "CustomAudioProcessor.h"
 #include "CustomAudioEditor.h"
 
-CustomAudioProcessor::CustomAudioProcessor() : RNBO::JuceAudioProcessor() {}
+CustomAudioProcessor::CustomAudioProcessor(const nlohmann::json& patcher_desc, const nlohmann::json& presets) : RNBO::JuceAudioProcessor(patcher_desc, presets) {}
 
 AudioProcessorEditor* CustomAudioProcessor::createEditor()
 {

--- a/src/CustomAudioProcessor.cpp
+++ b/src/CustomAudioProcessor.cpp
@@ -1,9 +1,43 @@
 #include "CustomAudioProcessor.h"
 #include "CustomAudioEditor.h"
+#include <json/json.hpp>
 
-CustomAudioProcessor::CustomAudioProcessor(const nlohmann::json& patcher_desc, const nlohmann::json& presets) : RNBO::JuceAudioProcessor(patcher_desc, presets) {}
+#ifdef RNBO_INCLUDE_DESCRIPTION_FILE
+#include <rnbo_description.h>
+#endif
+
+//create an instance of our custom plugin, optionally set description, presets and binary data (datarefs)
+CustomAudioProcessor* CustomAudioProcessor::CreateDefault() {
+	nlohmann::json patcher_desc, presets;
+
+#ifdef RNBO_BINARY_DATA_STORAGE_NAME
+	extern RNBO::BinaryDataImpl::Storage RNBO_BINARY_DATA_STORAGE_NAME;
+	RNBO::BinaryDataImpl::Storage dataStorage = RNBO_BINARY_DATA_STORAGE_NAME;
+#else
+	RNBO::BinaryDataImpl::Storage dataStorage;
+#endif
+	RNBO::BinaryDataImpl data(dataStorage);
+
+#ifdef RNBO_INCLUDE_DESCRIPTION_FILE
+	patcher_desc = RNBO::patcher_description;
+	presets = RNBO::patcher_presets;
+#endif
+  return new CustomAudioProcessor(patcher_desc, presets, data);
+}
+
+CustomAudioProcessor::CustomAudioProcessor(
+    const nlohmann::json& patcher_desc,
+    const nlohmann::json& presets,
+    const RNBO::BinaryData& data
+    ) 
+  : RNBO::JuceAudioProcessor(patcher_desc, presets, data) 
+{
+}
 
 AudioProcessorEditor* CustomAudioProcessor::createEditor()
 {
-    return new CustomAudioEditor (this, this->_rnboObject);
+    //Change this to use your CustomAudioEditor
+    //return new CustomAudioEditor (this, this->_rnboObject);
+    return RNBO::JuceAudioProcessor::createEditor();
 }
+

--- a/src/CustomAudioProcessor.h
+++ b/src/CustomAudioProcessor.h
@@ -1,10 +1,11 @@
 #include "RNBO.h"
 #include "RNBO_Utils.h"
 #include "RNBO_JuceAudioProcessor.h"
+#include <json/json.hpp>
 
 class CustomAudioProcessor : public RNBO::JuceAudioProcessor {
 public:
-    CustomAudioProcessor();
+    CustomAudioProcessor(const nlohmann::json& patcher_desc, const nlohmann::json& presets);
     juce::AudioProcessorEditor* createEditor() override;
 private:
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (CustomAudioProcessor)

--- a/src/CustomAudioProcessor.h
+++ b/src/CustomAudioProcessor.h
@@ -1,11 +1,13 @@
 #include "RNBO.h"
 #include "RNBO_Utils.h"
 #include "RNBO_JuceAudioProcessor.h"
+#include "RNBO_BinaryData.h"
 #include <json/json.hpp>
 
 class CustomAudioProcessor : public RNBO::JuceAudioProcessor {
 public:
-    CustomAudioProcessor(const nlohmann::json& patcher_desc, const nlohmann::json& presets);
+    static CustomAudioProcessor* CreateDefault();
+    CustomAudioProcessor(const nlohmann::json& patcher_desc, const nlohmann::json& presets, const RNBO::BinaryData& data);
     juce::AudioProcessorEditor* createEditor() override;
 private:
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (CustomAudioProcessor)

--- a/src/MainComponent.cpp
+++ b/src/MainComponent.cpp
@@ -2,11 +2,16 @@
 #define MAINCOMPONENT_H_INCLUDED
 
 #include "JuceHeader.h"
+#include <json/json.hpp>
 
 #include "RNBO.h"
 #include "RNBO_Utils.h"
 #include "RNBO_JuceAudioProcessor.h"
 // #include "CustomAudioProcessor.h"
+
+#ifdef RNBO_INCLUDE_DESCRIPTION_FILE
+#include <rnbo_description.h>
+#endif
 
 #include <array>
 
@@ -84,6 +89,7 @@ public:
 		false) // hide advanced options
     {
 		loadRNBOAudioProcessor();
+
 		RNBO::CoreObject& rnboObject = _audioProcessor->getRnboObject();
 
 		_deviceManager.initialiseWithDefaultDevices(rnboObject.getNumInputChannels(), rnboObject.getNumOutputChannels());
@@ -136,8 +142,14 @@ public:
 		unloadRNBOAudioProcessor();
 
 		jassert(_audioProcessor.get() == nullptr);
+    nlohmann::json patcher_desc, presets;
 
-		_audioProcessor = RNBO::make_unique<RNBO::JuceAudioProcessor>();
+#ifdef RNBO_INCLUDE_DESCRIPTION_FILE
+    patcher_desc = RNBO::patcher_description;
+    presets = RNBO::patcher_presets;
+#endif
+
+		_audioProcessor = RNBO::make_unique<RNBO::JuceAudioProcessor>(patcher_desc, presets);
 		// _audioProcessor = RNBO::make_unique<CustomAudioProcessor>();
 		RNBO::CoreObject& rnboObject = _audioProcessor->getRnboObject();
 		rnboObject.setPatcherChangedHandler(this);

--- a/src/MainComponent.cpp
+++ b/src/MainComponent.cpp
@@ -6,12 +6,7 @@
 
 #include "RNBO.h"
 #include "RNBO_Utils.h"
-#include "RNBO_JuceAudioProcessor.h"
-// #include "CustomAudioProcessor.h"
-
-#ifdef RNBO_INCLUDE_DESCRIPTION_FILE
-#include <rnbo_description.h>
-#endif
+#include "CustomAudioProcessor.h"
 
 #include <array>
 
@@ -142,15 +137,8 @@ public:
 		unloadRNBOAudioProcessor();
 
 		jassert(_audioProcessor.get() == nullptr);
-    nlohmann::json patcher_desc, presets;
 
-#ifdef RNBO_INCLUDE_DESCRIPTION_FILE
-    patcher_desc = RNBO::patcher_description;
-    presets = RNBO::patcher_presets;
-#endif
-
-		_audioProcessor = RNBO::make_unique<RNBO::JuceAudioProcessor>(patcher_desc, presets);
-		// _audioProcessor = RNBO::make_unique<CustomAudioProcessor>();
+		_audioProcessor = std::unique_ptr<CustomAudioProcessor>(CustomAudioProcessor::CreateDefault());
 		RNBO::CoreObject& rnboObject = _audioProcessor->getRnboObject();
 		rnboObject.setPatcherChangedHandler(this);
 
@@ -226,8 +214,7 @@ private:
 
 	std::unique_ptr<GrabFocusWhenShownComponentMovementWatcher> _keyboardFocusGrabber;
 
-	std::unique_ptr<RNBO::JuceAudioProcessor>	_audioProcessor;
-	// std::unique_ptr<CustomAudioProcessor>		_audioProcessor;
+	std::unique_ptr<CustomAudioProcessor>		_audioProcessor;
 	std::unique_ptr<AudioProcessorEditor>		_audioProcessorEditor;
 
 	// midi keyboard stuff

--- a/src/Plugin.cpp
+++ b/src/Plugin.cpp
@@ -1,21 +1,7 @@
-#include <RNBO_JuceAudioProcessor.h>
-#include <json/json.hpp>
-// #include "CustomAudioProcessor.h"
+#include "CustomAudioProcessor.h"
 
-#ifdef RNBO_INCLUDE_DESCRIPTION_FILE
-#include <rnbo_description.h>
-#endif
-
-//This creates new instances of your plugin, change RNBO::JuceAudioProcessor()
-//to your own class if you create a derived plugin
+//This creates new instances of your plugin
 juce::AudioProcessor* JUCE_CALLTYPE createPluginFilter()
 {
-	nlohmann::json patcher_desc, presets;
-
-#ifdef RNBO_INCLUDE_DESCRIPTION_FILE
-	patcher_desc = RNBO::patcher_description;
-	presets = RNBO::patcher_presets;
-#endif
-
-	return new RNBO::JuceAudioProcessor(patcher_desc, presets);
+  return CustomAudioProcessor::CreateDefault();
 }

--- a/src/Plugin.cpp
+++ b/src/Plugin.cpp
@@ -1,10 +1,21 @@
 #include <RNBO_JuceAudioProcessor.h>
+#include <json/json.hpp>
 // #include "CustomAudioProcessor.h"
+
+#ifdef RNBO_INCLUDE_DESCRIPTION_FILE
+#include <rnbo_description.h>
+#endif
 
 //This creates new instances of your plugin, change RNBO::JuceAudioProcessor()
 //to your own class if you create a derived plugin
 juce::AudioProcessor* JUCE_CALLTYPE createPluginFilter()
 {
-	return new RNBO::JuceAudioProcessor();
-	// return new CustomAudioProcessor();
+	nlohmann::json patcher_desc, presets;
+
+#ifdef RNBO_INCLUDE_DESCRIPTION_FILE
+	patcher_desc = RNBO::patcher_description;
+	presets = RNBO::patcher_presets;
+#endif
+
+	return new RNBO::JuceAudioProcessor(patcher_desc, presets);
 }


### PR DESCRIPTION
So RNBO itself now creates a binary data cpp file.. so this uses that.

The major changes are:
1) By default the template simply uses the custom adapter. You just have to change the code there to return the custom editor. I've updated the UI doc with that.
2) I've consolidated creation of the adapter, using it in both the plugin and the app, so that we can automatically load built in presets, patcher description and binary data (now part of rnbo's library code).
3) I've simplified the cmake setup to only specify the directory of the export, the rest of the details are computed but could easily be edited by users if they want. This just means there is less to specify in the initial case and you get what you get depending on how you export.